### PR TITLE
adding Term field to CommitTimeForm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.swp
 /db.sqlite3
 /settings.py
 /repositories/

--- a/ecegit/forms.py
+++ b/ecegit/forms.py
@@ -1,4 +1,5 @@
 from django import forms
 
 class CommitTimeForm(forms.Form):
+    term = forms.IntegerField(label="Term")
     timestamp = forms.DateTimeField(label="Timestamp")

--- a/ecegit/views.py
+++ b/ecegit/views.py
@@ -34,7 +34,7 @@ def setup(request):
 
 @login_required
 def commits_csv(request):
-    if not request.user.username in ['jeyolfso', 'drayside', 'a3zaman']:
+    if not request.user.username in ['jeyolfso', 'drayside', 'a3zaman', 'rbabaeec', 'j4bian', 'dhshin', 'talguind']:
         return HttpResponseForbidden()
 
     from .forms import CommitTimeForm

--- a/ecegit/views.py
+++ b/ecegit/views.py
@@ -42,6 +42,7 @@ def commits_csv(request):
     if request.method == 'POST':
         form = CommitTimeForm(request.POST)
         if form.is_valid():
+            term = str(form.cleaned_data['term'])
             timestamp = form.cleaned_data['timestamp']
             # timestamp = timezone('US/Eastern').localize(form.cleaned_data['timestamp'])
             import csv
@@ -52,10 +53,11 @@ def commits_csv(request):
             response['Content-Disposition'] = 'attachment; filename="commits.csv"'
             writer = csv.writer(response)
 
-            students = [x.decode() for x in check_output(['gitolite', 'list-members', '@ece351-1161-students']).splitlines()]
+            gitoliteStudentList = '@ece351-' + term + '-students'
+            students = [x.decode() for x in check_output(['gitolite', 'list-members', gitoliteStudentList]).splitlines()]
             for student in students:
                 pushes = Push.objects.filter(user__username=student,
-                                 repo__path='ece351/1161/{}/labs'.format(student),
+                                 repo__path=('ece351/' + term + '/{}/labs').format(student),
                                  time__lte=timestamp, refname='refs/heads/master').order_by('-time')
                 if pushes.count() > 0:
                     rev = pushes[0].new_rev


### PR DESCRIPTION
A slight generalization of the CommitTimeForm for ece351 that allows the term to be specified on the webform.

Also expands the list of ece351 staff who may submit the form.